### PR TITLE
add homepage and repo info

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
 	"name": "Home Note",
 	"description": "Plugin to open a choosen note each time joplin starts. It is like homepages on browsers.",
 	"author": "Adarsh Singh(lki)",
-	"homepage_url": "",
-	"repository_url": "",
+	"homepage_url": "https://github.com/lkiThakur/homenote#readme",
+	"repository_url": "https://github.com/lkiThakur/homenote",
 	"keywords": []
 }


### PR DESCRIPTION
This plugin has no info at all.

The PR adds the URLs for homepage and repo.

Please release version 1.0.1 so that this info will show up in the list. 